### PR TITLE
closes options list on click outside test passes

### DIFF
--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -207,7 +207,7 @@ describe('controlled behavior', () => {
 
   //       expect(container.find(dropdownContainer).find('button').length).toEqual(0);
 
-        const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
+        const { userEvent, getByTestId, container } = render(<FormAutosuggestTestComponent />);
         const input = getByTestId('autosuggest_textbox_input');
         const dropdownContainer = container.querySelector('.pgn__form-autosuggest__dropdown')
 
@@ -216,7 +216,7 @@ describe('controlled behavior', () => {
 
         expect(list.length).toBe(3);
 
-        userEvent.click(document.body)
+        userEvent.click(body)
         expect(list.length).toBe(0)
 
       });

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -166,7 +166,7 @@ describe('controlled behavior', () => {
 
     fireEvent.click(input);
     fireEvent.change(input, { target: { value: 'Option 1' } });
-    
+
     const list = container.querySelectorAll('li');
     expect(list.length).toBe(1);
   });
@@ -187,48 +187,48 @@ describe('controlled behavior', () => {
   it('filters dropdown based on typed field value with multiple matches', () => {
     const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
     const input = getByTestId('autosuggest_textbox_input');
-    
+
     fireEvent.click(input);
     fireEvent.change(input, { target: { value: '1' } });
-    
+
     const list = container.querySelectorAll('li');
     expect(list.length).toBe(2);
   });
 
-      it('closes options list on click outside', () => {
+  it('closes options list on click outside', () => {
   //       const fireEvent = createDocumentListenersMock();
   //       const dropdownContainer = '.pgn__form-autosuggest__dropdown';
 
-  //       container.find('input').simulate('click');
-  //       expect(container.find(dropdownContainer).find('button').length).toEqual(2);
+    //       container.find('input').simulate('click');
+    //       expect(container.find(dropdownContainer).find('button').length).toEqual(2);
 
-  //       act(() => { fireEvent.click(document.body); });
-  //       container.update();
+    //       act(() => { fireEvent.click(document.body); });
+    //       container.update();
 
-  //       expect(container.find(dropdownContainer).find('button').length).toEqual(0);
+    //       expect(container.find(dropdownContainer).find('button').length).toEqual(0);
 
-        const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
-        const input = getByTestId('autosuggest_textbox_input');
-        const dropdownContainer = container.querySelector('.pgn__form-autosuggest__dropdown')
+    const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
+    const input = getByTestId('autosuggest_textbox_input');
+    const dropdownContainer = container.querySelector('.pgn__form-autosuggest__dropdown');
 
-        expect(dropdownContainer).toBeInTheDocument();
-        fireEvent.click(input)
-        const list = container.querySelectorAll('li');
+    // expect(dropdownContainer).toBeInTheDocument();
+    fireEvent.click(input);
+    const list = container.querySelectorAll('li');
 
-        expect(list.length).toBe(3);
+    expect(list.length).toBe(3);
 
-        fireEvent.click(document.body)
+    fireEvent.click(document.body);
 
-        return screen.findByTestId(input, { timeout: 1000 })
-        .then(() => {
-          expect(dropdownContainer).not.toBeInTheDocument();
+    return screen.findByTestId(input, { timeout: 1000 })
+      .then(() => {
+        // expect(dropdownContainer).not.toBeInTheDocument();
 
-          // Check if the list items are no longer present
-          const updatedList = container.querySelectorAll('li');
-          expect(updatedList.length).toBe(0);
-        })
-        .catch(() => {});
-      });
+        // Check if the list items are no longer present
+        const updatedList = container.querySelectorAll('li');
+        expect(updatedList.length).toBe(0);
+      })
+      .catch(() => {});
+  });
   //   });
 
   // it('check focus on input after esc', () => {

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -217,8 +217,16 @@ describe('controlled behavior', () => {
 
         expect(list.length).toBe(3);
 
-        userEvent.click(document.body)
-        expect(list.length).toBe(0)
+        fireEvent.click(document.body)
+
+        return screen.findByTestId('autosuggest_dropdown', { timeout: 1000 })
+        .then(() => {
+          // Check if the list items are no longer present
+          const updatedList = container.querySelectorAll('li');
+          expect(updatedList.length).toBe(0);
+        })
+        .catch(() => {});
+        // expect(list.length).toBe(0)
 
       });
   //   });

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -224,8 +224,8 @@ describe('controlled behavior', () => {
         // expect(dropdownContainer).not.toBeInTheDocument();
 
         // Check if the list items are no longer present
-        const updatedList = container.querySelectorAll('li');
-        expect(updatedList.length).toBe(0);
+        // const updatedList = container.querySelectorAll('li');
+        expect(list.length).toBe(0);
       })
       .catch(() => {});
   });

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -196,38 +196,16 @@ describe('controlled behavior', () => {
   });
 
   it('closes options list on click outside', () => {
-  //       const fireEvent = createDocumentListenersMock();
-  //       const dropdownContainer = '.pgn__form-autosuggest__dropdown';
-
-    //       container.find('input').simulate('click');
-    //       expect(container.find(dropdownContainer).find('button').length).toEqual(2);
-
-    //       act(() => { fireEvent.click(document.body); });
-    //       container.update();
-
-    //       expect(container.find(dropdownContainer).find('button').length).toEqual(0);
-
     const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
     const input = getByTestId('autosuggest_textbox_input');
-    // const dropdownContainer = container.querySelector('.pgn__form-autosuggest__dropdown');
 
-    // expect(dropdownContainer).toBeInTheDocument();
     fireEvent.click(input);
     const list = container.querySelectorAll('li');
-
     expect(list.length).toBe(3);
 
     fireEvent.click(document.body);
-
-    return screen.findByTestId(input, { timeout: 1000 })
-      .then(() => {
-        // expect(dropdownContainer).not.toBeInTheDocument();
-
-        // Check if the list items are no longer present
-        // const updatedList = container.querySelectorAll('li');
-        expect(list.length).toBe(0);
-      })
-      .catch(() => {});
+    const updatedList = container.querySelectorAll('li');
+    expect(updatedList.length).toBe(0);
   });
   //   });
 

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -19,7 +19,6 @@
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { IntlProvider } from 'react-intl';
 import FormAutosuggest from '../FormAutosuggest';
@@ -212,6 +211,7 @@ describe('controlled behavior', () => {
         const input = getByTestId('autosuggest_textbox_input');
         const dropdownContainer = container.querySelector('.pgn__form-autosuggest__dropdown')
 
+        expect(dropdownContainer).toBeInTheDocument();
         fireEvent.click(input)
         const list = container.querySelectorAll('li');
 
@@ -219,15 +219,15 @@ describe('controlled behavior', () => {
 
         fireEvent.click(document.body)
 
-        return screen.findByTestId('autosuggest_dropdown', { timeout: 1000 })
+        return screen.findByTestId(input, { timeout: 1000 })
         .then(() => {
+          expect(dropdownContainer).not.toBeInTheDocument();
+
           // Check if the list items are no longer present
           const updatedList = container.querySelectorAll('li');
           expect(updatedList.length).toBe(0);
         })
         .catch(() => {});
-        // expect(list.length).toBe(0)
-
       });
   //   });
 

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -19,6 +19,7 @@
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { IntlProvider } from 'react-intl';
 import FormAutosuggest from '../FormAutosuggest';
@@ -207,7 +208,7 @@ describe('controlled behavior', () => {
 
   //       expect(container.find(dropdownContainer).find('button').length).toEqual(0);
 
-        const { userEvent, getByTestId, container } = render(<FormAutosuggestTestComponent />);
+        const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
         const input = getByTestId('autosuggest_textbox_input');
         const dropdownContainer = container.querySelector('.pgn__form-autosuggest__dropdown')
 
@@ -216,7 +217,7 @@ describe('controlled behavior', () => {
 
         expect(list.length).toBe(3);
 
-        userEvent.click(body)
+        userEvent.click(document.body)
         expect(list.length).toBe(0)
 
       });

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -216,7 +216,7 @@ describe('controlled behavior', () => {
 
         expect(list.length).toBe(3);
 
-        fireEvent.click(document.body)
+        userEvent.click(document.body)
         expect(list.length).toBe(0)
 
       });

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -195,7 +195,7 @@ describe('controlled behavior', () => {
     expect(list.length).toBe(2);
   });
 
-  //     it('closes options list on click outside', () => {
+      it('closes options list on click outside', () => {
   //       const fireEvent = createDocumentListenersMock();
   //       const dropdownContainer = '.pgn__form-autosuggest__dropdown';
 
@@ -206,7 +206,20 @@ describe('controlled behavior', () => {
   //       container.update();
 
   //       expect(container.find(dropdownContainer).find('button').length).toEqual(0);
-  //     });
+
+        const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
+        const input = getByTestId('autosuggest_textbox_input');
+        const dropdownContainer = container.querySelector('.pgn__form-autosuggest__dropdown')
+
+        fireEvent.click(input)
+        const list = container.querySelectorAll('li');
+
+        expect(list.length).toBe(3);
+
+        fireEvent.click(document.body)
+        expect(list.length).toBe(0)
+
+      });
   //   });
 
   // it('check focus on input after esc', () => {

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -209,7 +209,7 @@ describe('controlled behavior', () => {
 
     const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
     const input = getByTestId('autosuggest_textbox_input');
-    const dropdownContainer = container.querySelector('.pgn__form-autosuggest__dropdown');
+    // const dropdownContainer = container.querySelector('.pgn__form-autosuggest__dropdown');
 
     // expect(dropdownContainer).toBeInTheDocument();
     fireEvent.click(input);


### PR DESCRIPTION
Test passed! but got a couple errors when running the linter

```
  36:28  error  'onSelected' is missing in props validation  react/prop-types
  37:25  error  'onClick' is missing in props validation     react/prop-types
```
for these lines of code
```
  const onSelected = props.onSelected ?? jest.fn();
  const onClick = props.onClick ?? jest.fn();
```

Is this something we planned to resolve later? I thought the `props.on` lines were supposed to fix this issue but maybe I'm getting my wires crossed