### PR TITLE
Toggles options list test passed but getting the same linting errors

### DIFF
--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -173,15 +173,19 @@ describe('controlled behavior', () => {
 
       it('toggles options list', () => {
       //  this is toggling when the dropdown button is clicked
-        const dropdownContainer = '.pgn__form-autosuggest__dropdown';
+        // const dropdownContainer = '.pgn__form-autosuggest__dropdown';
 
         // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
         
-        container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-        expect(container.find(dropdownContainer).find('button').length).toEqual(0);
+        // container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
+        // expect(container.find(dropdownContainer).find('button').length).toEqual(0);
 
-        container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-        expect(container.find(dropdownContainer).find('button').length).toEqual(3);
+        // container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
+        // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
+
+        const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
+
+        const dropdownBtn = container.querySelector('button.pgn__form-autosuggest__icon-button')
 
         const list = container.querySelectorAll('li');
         expect(list.length).toBe(3);

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -172,34 +172,20 @@ describe('controlled behavior', () => {
   });
 
   it('toggles options list', () => {
-    //  this is toggling when the dropdown button is clicked
-    // const dropdownContainer = '.pgn__form-autosuggest__dropdown';
-
-    // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
-
-    // container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-    // expect(container.find(dropdownContainer).find('button').length).toEqual(0);
-
-    // container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-    // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
-
     const { container } = render(<FormAutosuggestTestComponent />);
     const dropdownBtn = container.querySelector('button.pgn__form-autosuggest__icon-button');
 
     fireEvent.click(dropdownBtn);
-
     const list = container.querySelectorAll('li');
     expect(list.length).toBe(3);
 
     fireEvent.click(dropdownBtn);
-    // Re-query the list of elements again after the second click
     const updatedList = container.querySelectorAll('li');
-
     expect(updatedList.length).toBe(0);
 
-    // is this last bit necessary?
     fireEvent.click(dropdownBtn);
-    expect(list.length).toBe(3);
+    const reopenedList = container.querySelectorAll('li');
+    expect(reopenedList.length).toBe(3);
   });
 
   it('filters dropdown based on typed field value with multiple matches', () => {

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -171,18 +171,18 @@ describe('controlled behavior', () => {
     expect(list.length).toBe(1);
   });
 
-  //     it('toggles options list', () => {
-  //      this is toggling when the dropdown button is clicked
-  //       const dropdownContainer = '.pgn__form-autosuggest__dropdown';
+      it('toggles options list', () => {
+       this is toggling when the dropdown button is clicked
+        const dropdownContainer = '.pgn__form-autosuggest__dropdown';
 
-  //       expect(container.find(dropdownContainer).find('button').length).toEqual(3);
+        expect(container.find(dropdownContainer).find('button').length).toEqual(3);
 
-  //       container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-  //       expect(container.find(dropdownContainer).find('button').length).toEqual(0);
+        container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
+        expect(container.find(dropdownContainer).find('button').length).toEqual(0);
 
-  //       container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-  //       expect(container.find(dropdownContainer).find('button').length).toEqual(3);
-  //     });
+        container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
+        expect(container.find(dropdownContainer).find('button').length).toEqual(3);
+      });
 
   it('filters dropdown based on typed field value with multiple matches', () => {
     const { getByTestId, container } = render(<FormAutosuggestTestComponent />);

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -184,11 +184,15 @@ describe('controlled behavior', () => {
         // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
 
         const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
+        const dropdownBtn = container.querySelector('button.pgn__form-autosuggest__icon-button');
 
-        const dropdownBtn = container.querySelector('button.pgn__form-autosuggest__icon-button')
+        fireEvent.click(dropdownBtn);
 
         const list = container.querySelectorAll('li');
         expect(list.length).toBe(3);
+
+        fireEvent.click(dropdownBtn);
+        expect(list.length).toBe(0);
       });
 
   it('filters dropdown based on typed field value with multiple matches', () => {

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -166,42 +166,42 @@ describe('controlled behavior', () => {
 
     fireEvent.click(input);
     fireEvent.change(input, { target: { value: 'Option 1' } });
-    
+
     const list = container.querySelectorAll('li');
     expect(list.length).toBe(1);
   });
 
-      it('toggles options list', () => {
-      //  this is toggling when the dropdown button is clicked
-        // const dropdownContainer = '.pgn__form-autosuggest__dropdown';
+  it('toggles options list', () => {
+    //  this is toggling when the dropdown button is clicked
+    // const dropdownContainer = '.pgn__form-autosuggest__dropdown';
 
-        // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
-        
-        // container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-        // expect(container.find(dropdownContainer).find('button').length).toEqual(0);
+    // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
 
-        // container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
-        // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
+    // container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
+    // expect(container.find(dropdownContainer).find('button').length).toEqual(0);
 
-        const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
-        const dropdownBtn = container.querySelector('button.pgn__form-autosuggest__icon-button');
+    // container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
+    // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
 
-        fireEvent.click(dropdownBtn);
+    const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
+    const dropdownBtn = container.querySelector('button.pgn__form-autosuggest__icon-button');
 
-        const list = container.querySelectorAll('li');
-        expect(list.length).toBe(3);
+    fireEvent.click(dropdownBtn);
 
-        fireEvent.click(dropdownBtn);
-        expect(list.length).toBe(0);
-      });
+    const list = container.querySelectorAll('li');
+    expect(list.length).toBe(3);
+
+    fireEvent.click(dropdownBtn);
+    expect(list.length).toBe(0);
+  });
 
   it('filters dropdown based on typed field value with multiple matches', () => {
     const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
     const input = getByTestId('autosuggest_textbox_input');
-    
+
     fireEvent.click(input);
     fireEvent.change(input, { target: { value: '1' } });
-    
+
     const list = container.querySelectorAll('li');
     expect(list.length).toBe(2);
   });

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -172,16 +172,19 @@ describe('controlled behavior', () => {
   });
 
       it('toggles options list', () => {
-       this is toggling when the dropdown button is clicked
+      //  this is toggling when the dropdown button is clicked
         const dropdownContainer = '.pgn__form-autosuggest__dropdown';
 
-        expect(container.find(dropdownContainer).find('button').length).toEqual(3);
-
+        // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
+        
         container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
         expect(container.find(dropdownContainer).find('button').length).toEqual(0);
 
         container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
         expect(container.find(dropdownContainer).find('button').length).toEqual(3);
+
+        const list = container.querySelectorAll('li');
+        expect(list.length).toBe(3);
       });
 
   it('filters dropdown based on typed field value with multiple matches', () => {

--- a/src/Form/tests/FormAutosuggest.test.jsx
+++ b/src/Form/tests/FormAutosuggest.test.jsx
@@ -183,7 +183,7 @@ describe('controlled behavior', () => {
     // container.find('button.pgn__form-autosuggest__icon-button').simulate('click');
     // expect(container.find(dropdownContainer).find('button').length).toEqual(3);
 
-    const { getByTestId, container } = render(<FormAutosuggestTestComponent />);
+    const { container } = render(<FormAutosuggestTestComponent />);
     const dropdownBtn = container.querySelector('button.pgn__form-autosuggest__icon-button');
 
     fireEvent.click(dropdownBtn);
@@ -192,7 +192,14 @@ describe('controlled behavior', () => {
     expect(list.length).toBe(3);
 
     fireEvent.click(dropdownBtn);
-    expect(list.length).toBe(0);
+    // Re-query the list of elements again after the second click
+    const updatedList = container.querySelectorAll('li');
+
+    expect(updatedList.length).toBe(0);
+
+    // is this last bit necessary?
+    fireEvent.click(dropdownBtn);
+    expect(list.length).toBe(3);
   });
 
   it('filters dropdown based on typed field value with multiple matches', () => {


### PR DESCRIPTION
Errors:
```
  36:28  error  'onSelected' is missing in props validation  react/prop-types
  37:25  error  'onClick' is missing in props validation     react/prop-types
```
for these lines of code
```
  const onSelected = props.onSelected ?? jest.fn();
  const onClick = props.onClick ?? jest.fn();
```

Is this something we planned to resolve later? I thought the `props.on` lines were supposed to fix this issue but maybe I'm getting my wires crossed